### PR TITLE
fix name conflicts

### DIFF
--- a/comparison-with-state-of-the-art/eval/plot.py
+++ b/comparison-with-state-of-the-art/eval/plot.py
@@ -92,7 +92,7 @@ FUZZER_COLOR = {
     "sgfuzz": "#808b88",
 }
 
-ROOT = Path("artifact-results")
+ROOT = Path("artifact-results-test")
 RESULT_DIR = ROOT / "finished"
 CHARTS_DIR = ROOT / "charts"
 CHARTS_SVG_DIR = CHARTS_DIR / "svg"

--- a/comparison-with-state-of-the-art/eval/src/remote.py
+++ b/comparison-with-state-of-the-art/eval/src/remote.py
@@ -265,7 +265,7 @@ class Executor:
         ]
 
         volumes: typing.Dict[str, typing.Dict[str,str]] = {}
-        if self._image_name == "fuzztruction-env":
+        if self._image_name == "fuzztruction-net-env":
             home_dir_path = self._remote.execute_on_remote(["echo $HOME"]).stdout.strip()
             fuzztruction_dir = Path(home_dir_path) / "fuzztruction-net"
 


### PR DESCRIPTION
Changes: 
* https://github.com/fuzztruction/fuzztruction-net/blob/681e25417b1773515c1c0e74cf0dc611ba052f9d/env/config.sh#L4  defines the image name as `fuzztruction-net-env`. But in remote.py it checks if the image name is `fuzztruction-env`. So it always assumes the prebuilt image is used and later on fails 
* The example campaign-config.yaml defines the `result-path: "./artifact-results-test"`, [link](https://github.com/fuzztruction/fuzztruction-net-experiments/blob/ec7935aadd38432b8fe96e2307614525d9ae0ff1/comparison-with-state-of-the-art/eval/campaign-config.yaml#L2) but the plotting script tries to use `"artifact-results"`